### PR TITLE
correctly pass 'canary' parameter in patch.bat

### DIFF
--- a/patch.bat
+++ b/patch.bat
@@ -6,6 +6,6 @@ adb -e push magisk_emu.zip /data/local/tmp/magisk.zip
 adb -e push update-binary /data/local/tmp
 adb -e push process.sh /data/local/tmp
 adb -e shell "dos2unix /data/local/tmp/process.sh"
-adb -e shell "sh /data/local/tmp/process.sh /data/local/tmp $1"
+adb -e shell "sh /data/local/tmp/process.sh /data/local/tmp %1"
 adb -e pull /data/local/tmp/ramdisk.img
 


### PR DESCRIPTION
I missed this in last pullrequest. Now, I tested it with %1 instead of $1 and it works as expected, successfully patching the ramdisk on windows.